### PR TITLE
Created a Reusable Button Component with Variants

### DIFF
--- a/Components/ui/Button.tsx
+++ b/Components/ui/Button.tsx
@@ -3,7 +3,13 @@ import clsx from "clsx";
 interface ButtonProps {
   children: React.ReactNode | string;
   onClick?: () => void;
-  variant: "primary" | "secondary" | "outline" | "gradient";
+  variant:
+    | "primary"
+    | "secondary"
+    | "outline"
+    | "gradient"
+    | "dark-outline"
+    | "dim-secondary";
   type?: "button" | "submit" | "reset";
   size?: "sm" | "md" | "lg";
   className?: string;
@@ -37,6 +43,10 @@ const Button = ({
             variant === "outline",
           "bg-gradient-to-l from-[#10B981] to-[#0C191FC9] w-[101px] h-[46px] text-white font-[700] text-[16px]":
             variant === "gradient",
+          "bg-transparent border-[#00000] border-[1px] border-solid w-[101px] h-[46px] text-white font-[700] text-[16px]":
+            variant === "dark-outline",
+          "bg-transparent border-[#059669] border-[1px] border-solid w-[101px] h-[46px] text-white font-[700] text-[16px]":
+            variant === "dim-secondary",
         },
       )}
       onClick={onClick}

--- a/Components/ui/Button.tsx
+++ b/Components/ui/Button.tsx
@@ -1,0 +1,49 @@
+import clsx from "clsx";
+
+interface ButtonProps {
+  children: React.ReactNode | string;
+  onClick?: () => void;
+  variant: "primary" | "secondary" | "outline" | "gradient";
+  type?: "button" | "submit" | "reset";
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const Button = ({
+  children,
+  onClick,
+  variant,
+  size,
+  type = "button",
+  className,
+}: ButtonProps) => {
+  return (
+    <button
+      type={type}
+      className={clsx(
+        "cursor-pointer px-6 rounded-[8px] w-[101px] h-[46px] font-semibold",
+        className,
+        {
+          // size variation
+          "w-[101px] h-[46px] text-[14px]": size === "sm",
+          "w-[115px] h-[46px] text-[16px]": size === "md",
+          "w-[130px] h-[52px] text-[18px]": size === "lg",
+          // type variation
+          "bg-[#8D9094] text-black font-[700] text-[16px]":
+            variant === "primary",
+          "bg-[#059669] text-white font-[700] text-[16px]":
+            variant === "secondary",
+          "bg-transparent border-[#10B981] border-[1px] border-solid w-[101px] h-[46px] text-white font-[700] text-[16px]":
+            variant === "outline",
+          "bg-gradient-to-l from-[#10B981] to-[#0C191FC9] w-[101px] h-[46px] text-white font-[700] text-[16px]":
+            variant === "gradient",
+        },
+      )}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.1",
         "axios": "^1.7.9",
+        "clsx": "^2.1.1",
         "next": "14.2.23",
         "next-auth": "^4.24.11",
         "react": "^18",
@@ -1345,6 +1346,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.1",
     "axios": "^1.7.9",
+    "clsx": "^2.1.1",
     "next": "14.2.23",
     "next-auth": "^4.24.11",
     "react": "^18",


### PR DESCRIPTION
feat-#41

This PR introduces a reusable Button component that supports multiple variants (e.g., primary, secondary, outline, gradient) and a size prop that allows customization of the button's width, height, and font size. This component can be easily extended for other button variants and provides flexibility in styling based on the user’s needs.

### Changes:

- Created a reusable Button component in Button.tsx.

- Added support for the following variants:
    *primary: A solid button with a default color.
     *secondary: A solid button with a secondary color.
    *outline: A transparent button with a border.
    *gradient: A button with a gradient background.

- Added a size prop with the following options:

    *sm: Small button (80px width, 36px height, 14px text).
    *md: Medium button (default, 101px width, 46px height, 16px text).
    *lg: Large button (120px width, 54px height, 18px text).

-Used clsx for conditional class names to ensure the component is easily extendable.
Enhanced the component's design.





<img width="639" alt="Screenshot 2025-01-28 182242" src="https://github.com/user-attachments/assets/c0d62e8a-38f7-47ab-9d9a-ae185b70ab57" />
