### PR TITLE
Implement notification system with dropdown and toast notifications

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Providers from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Toaster } from "react-hot-toast";
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <Toaster position="top-right" />
+    </>
+  );
+}

--- a/components/notifications/NotificationDropdown.tsx
+++ b/components/notifications/NotificationDropdown.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import NotificationItem from "./NotificationItem";
+import { AppNotification } from "@/lib/types/notifications";
+
+export default function NotificationDropdown({
+  open,
+  notifications,
+  onClose,
+}: {
+  open: boolean;
+  notifications: AppNotification[];
+  onClose: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="absolute right-0 mt-2 w-80 rounded-xl border bg-white shadow-lg overflow-hidden z-50">
+      <div className="flex items-center justify-between px-4 py-3 border-b">
+        <p className="text-sm font-semibold">Notifications</p>
+        <button
+          onClick={onClose}
+          className="text-xs text-gray-500 hover:text-gray-800"
+        >
+          Close
+        </button>
+      </div>
+
+      <div className="max-h-[360px] overflow-auto p-2">
+        {notifications.length === 0 ? (
+          <p className="text-sm text-gray-500 px-3 py-6 text-center">
+            No notifications yet
+          </p>
+        ) : (
+          <div className="space-y-1">
+            {notifications.map((n) => (
+              <NotificationItem key={n.id} notification={n} onClick={onClose} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/notifications/NotificationItem.tsx
+++ b/components/notifications/NotificationItem.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Link from "next/link";
+import { AppNotification } from "@/lib/types/notifications";
+
+export default function NotificationItem({
+  notification,
+  onClick,
+}: {
+  notification: AppNotification;
+  onClick?: () => void;
+}) {
+  if (notification.type !== "capsule_unlocked") return null;
+
+  const capsuleHref = `/capsules/${notification.capsuleId}`;
+
+  return (
+    <Link
+      href={capsuleHref}
+      onClick={onClick}
+      className="block rounded-lg px-3 py-2 hover:bg-gray-50 transition"
+    >
+      <p className="text-sm font-medium">Capsule unlocked 🎉</p>
+      <p className="text-xs text-gray-600">
+        {notification.capsuleTitle ?? "View unlocked capsule"}
+      </p>
+      <p className="text-[11px] text-gray-400 mt-1">
+        {new Date(notification.unlockedAt).toLocaleString()}
+      </p>
+    </Link>
+  );
+}

--- a/components/notifications/NotitficationBell.tsx
+++ b/components/notifications/NotitficationBell.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useCapsuleUnlockNotifications } from "@/lib/hooks/useCapsuleUnlockNotifications";
+import NotificationDropdown from "./NotificationDropdown";
+
+export default function NotificationBell() {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const { notifications, unreadCount } = useCapsuleUnlockNotifications(10000);
+
+  // close dropdown on outside click
+  useEffect(() => {
+    function handleOutsideClick(e: MouseEvent) {
+      if (!containerRef.current) return;
+
+      if (!containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleOutsideClick);
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        className="relative rounded-full p-2 hover:bg-gray-100 transition"
+        aria-label="Notifications"
+      >
+        {/* simple bell icon */}
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          className="text-gray-800"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2Zm6-6V11a6 6 0 0 0-5-5.91V4a1 1 0 1 0-2 0v1.09A6 6 0 0 0 6 11v5l-2 2v1h16v-1l-2-2Z"
+            fill="currentColor"
+          />
+        </svg>
+
+        {/* badge */}
+        {unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 text-[11px] font-bold rounded-full bg-red-600 text-white flex items-center justify-center">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      <NotificationDropdown
+        open={open}
+        notifications={notifications}
+        onClose={() => setOpen(false)}
+      />
+    </div>
+  );
+}

--- a/hooks/useCapsuleUnlockNotifications.ts
+++ b/hooks/useCapsuleUnlockNotifications.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { getNotifications } from "@/lib/api/notifications";
+import { AppNotification } from "@/lib/types/notifications";
+
+export function useCapsuleUnlockNotifications(pollIntervalMs = 10000) {
+  const [notifications, setNotifications] = useState<AppNotification[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const seenIdsRef = useRef<Set<string>>(new Set());
+
+  const unreadCount = useMemo(() => {
+    return notifications.filter((n) => n.read === false || n.read === undefined).length;
+  }, [notifications]);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout | null = null;
+    let cancelled = false;
+
+    const fetchNotifications = async () => {
+      try {
+        const data = await getNotifications();
+
+        if (cancelled) return;
+
+        // detect new ones for toast
+        for (const n of data) {
+          if (!seenIdsRef.current.has(n.id)) {
+            // new notification detected
+            if (n.type === "capsule_unlocked") {
+              toast.success(`Capsule unlocked: ${n.capsuleTitle ?? n.capsuleId}`);
+            }
+
+            seenIdsRef.current.add(n.id);
+          }
+        }
+
+        setNotifications(data);
+      } catch (err) {
+        // optional: silence errors to avoid annoying users
+        // console.error(err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchNotifications();
+
+    timer = setInterval(fetchNotifications, pollIntervalMs);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+    };
+  }, [pollIntervalMs]);
+
+  return {
+    notifications,
+    unreadCount,
+    loading,
+    setNotifications, // in case you want to mark read locally
+  };
+}

--- a/lib/api/notifications.ts
+++ b/lib/api/notifications.ts
@@ -1,0 +1,23 @@
+import { AppNotification } from "@/lib/types/notifications";
+
+type GetNotificationsResponse = {
+  data: AppNotification[];
+};
+
+export async function getNotifications(): Promise<AppNotification[]> {
+  // ✅ update endpoint here if backend uses a different route
+  const res = await fetch("/api/notifications?type=capsule_unlocked", {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch notifications");
+  }
+
+  const json = (await res.json()) as GetNotificationsResponse;
+  return json.data ?? [];
+}

--- a/lib/types/notifications.ts
+++ b/lib/types/notifications.ts
@@ -1,0 +1,10 @@
+export type CapsuleUnlockedNotification = {
+  id: string;
+  type: "capsule_unlocked";
+  capsuleId: string;
+  capsuleTitle?: string;
+  unlockedAt: string;
+  read?: boolean;
+};
+
+export type AppNotification = CapsuleUnlockedNotification;


### PR DESCRIPTION
## ✅ Capsule Unlock Notifications

### Summary
Notifies users when a capsule unlocks via a notification bell badge, dropdown alerts, and optional toast notifications. Alerts link directly to the unlocked capsule.

### Changes
- Added notification bell + unread badge
- Added dropdown notification list
- Added toast alerts for new unlocks
- Added deep link to `/capsules/[capsuleId]`

### API
Polls: `GET /api/notifications?type=capsule_unlocked`  
(Update in `lib/api/notifications.ts` if needed)

### Files
**Added**
- `app/providers.tsx`
- `components/notifications/*`
- `lib/api/notifications.ts`
- `lib/hooks/useCapsuleUnlockNotifications.ts`
- `lib/types/notifications.ts`

**Updated**
- `app/layout.tsx`
- `components/layout/Navbar.tsx`

### Acceptance Criteria
✅ User is notified when capsule unlocks  
✅ Notification links correctly

closes #235 