### PR TITLE
feat(api): implement fetch capsules endpoints

### DIFF
--- a/backend/src/capsules/capsules.controller.ts
+++ b/backend/src/capsules/capsules.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Param, UseGuards, Request } from '@nestjs/common';
+import { CapsulesService } from './capsules.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'; // Assumes standard Guard location
+
+@Controller('api/capsules')
+@UseGuards(JwtAuthGuard)
+export class CapsulesController {
+  constructor(private readonly capsulesService: CapsulesService) {}
+
+  @Get()
+  findAll(@Request() req) {
+    // req.user.userId comes from JWT strategy
+    return this.capsulesService.findAll(req.user.userId);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string, @Request() req) {
+    return this.capsulesService.findOne(id, req.user.userId);
+  }
+}

--- a/backend/src/capsules/capsules.module.ts
+++ b/backend/src/capsules/capsules.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CapsulesService } from './capsules.service';
+import { CapsulesController } from './capsules.controller';
+import { Capsule } from './entities/capsule.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Capsule])],
+  controllers: [CapsulesController],
+  providers: [CapsulesService],
+})
+export class CapsulesModule {}

--- a/backend/src/capsules/capsules.service.ts
+++ b/backend/src/capsules/capsules.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Capsule } from './entities/capsule.entity'; // Assumes entity exists
+
+@Injectable()
+export class CapsulesService {
+  constructor(
+    @InjectRepository(Capsule)
+    private capsulesRepository: Repository<Capsule>,
+  ) {}
+
+  async findAll(userId: string) {
+    const capsules = await this.capsulesRepository.find({
+      where: { user: { id: userId } },
+      order: { createdAt: 'DESC' },
+    });
+
+    return capsules.map(capsule => this.sanitizeCapsule(capsule));
+  }
+
+  async findOne(id: string, userId: string) {
+    const capsule = await this.capsulesRepository.findOne({
+      where: { id, user: { id: userId } },
+    });
+
+    if (!capsule) {
+      throw new NotFoundException('Capsule not found');
+    }
+
+    return this.sanitizeCapsule(capsule);
+  }
+
+  private sanitizeCapsule(capsule: Capsule): Capsule {
+    const now = new Date();
+    // If unlock date is in the future, remove the content
+    if (capsule.unlockDate && new Date(capsule.unlockDate) > now) {
+      capsule.content = null; // Or '[LOCKED]'
+      capsule.isLocked = true; // Helper flag for frontend
+    } else {
+      capsule.isLocked = false;
+    }
+    return capsule;
+  }
+}


### PR DESCRIPTION
- Added `GET` `/api/capsules` to list user capsules
- Added `GET` `/api/capsules/:id` for single details
- Implemented security check to redact content if unlockDate > now
- Enforced ownership check (only returns user's own capsules)

Closes #232