### PR TITLE
Add DB seed script and faker dev dependency

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,9 @@
     "build": "tsc",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"No tests configured yet for api\""
+    "test": "echo \"No tests configured yet for api\"",
+    "seed": "ts-node -P tsconfig.scripts.json scripts/seed.ts",
+    "seed:teardown": "ts-node -P tsconfig.scripts.json scripts/seed.ts --teardown"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@faker-js/faker": "^10.3.0",
     "@ourkairos/config": "workspace:*",
     "@types/cors": "^2.8.19",
     "@types/eslint": "^9.6.1",

--- a/apps/api/scripts/seed.ts
+++ b/apps/api/scripts/seed.ts
@@ -1,0 +1,216 @@
+import path from 'node:path';
+import dotenv from 'dotenv';
+import mongoose, { Types } from 'mongoose';
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env') });
+
+type CapsuleStatus = 'DRAFT' | 'SEALED' | 'UNLOCKED';
+
+type UserSeed = {
+  _id: Types.ObjectId;
+  id: string;
+  email: string;
+  name: string;
+  avatarUrl: string | null;
+  provider: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type CapsuleSeed = {
+  _id: Types.ObjectId;
+  id: string;
+  ownerId: string;
+  title: string;
+  message: string | null;
+  unlockDate: Date | null;
+  status: CapsuleStatus;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type FakerLike = {
+  seed: (seed: number) => number;
+  image: { avatar: () => string };
+  lorem: {
+    sentence: () => string;
+    paragraph: () => string;
+  };
+};
+
+const TOTAL_CAPSULES = 60;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const buildObjectId = (seed: number): Types.ObjectId =>
+  new Types.ObjectId(seed.toString(16).padStart(24, '0'));
+
+const addDays = (daysFromNow: number): Date =>
+  new Date(Date.now() + daysFromNow * DAY_MS);
+
+const loadFaker = async (): Promise<FakerLike> => {
+  try {
+    const module = (await import('@faker-js/faker')) as { faker?: FakerLike };
+    if (!module.faker) {
+      throw new Error('Missing faker export');
+    }
+    return module.faker;
+  } catch {
+    throw new Error(
+      'Missing dependency "@faker-js/faker". Run: pnpm --filter api add -D @faker-js/faker',
+    );
+  }
+};
+
+const buildUsers = (faker: FakerLike): UserSeed[] => {
+  const now = new Date();
+  const baseline = new Date(now.getTime() - 30 * DAY_MS);
+
+  const firstId = buildObjectId(1001);
+  const secondId = buildObjectId(1002);
+  const thirdId = buildObjectId(1003);
+
+  return [
+    {
+      _id: firstId,
+      id: firstId.toHexString(),
+      email: 'test1@ourkairos.com',
+      name: 'Test User One',
+      avatarUrl: faker.image.avatar(),
+      provider: 'credentials',
+      createdAt: baseline,
+      updatedAt: now,
+    },
+    {
+      _id: secondId,
+      id: secondId.toHexString(),
+      email: 'test2@ourkairos.com',
+      name: 'Test User Two',
+      avatarUrl: faker.image.avatar(),
+      provider: 'google',
+      createdAt: baseline,
+      updatedAt: now,
+    },
+    {
+      _id: thirdId,
+      id: thirdId.toHexString(),
+      email: 'test3@ourkairos.com',
+      name: 'Test User Three',
+      avatarUrl: faker.image.avatar(),
+      provider: 'credentials',
+      createdAt: baseline,
+      updatedAt: now,
+    },
+  ];
+};
+
+const resolveCapsuleStatus = (index: number): CapsuleStatus => {
+  const remainder = index % 5;
+  if (remainder === 0 || remainder === 1) return 'DRAFT';
+  if (remainder === 2 || remainder === 3) return 'SEALED';
+  return 'UNLOCKED';
+};
+
+const resolveUnlockDate = (status: CapsuleStatus, index: number): Date | null => {
+  if (status === 'DRAFT') {
+    if (index % 3 === 0) return null;
+    return addDays(2 + (index % 30));
+  }
+  if (status === 'SEALED') return addDays(5 + (index % 45));
+  return addDays(-(1 + (index % 20)));
+};
+
+const buildCapsules = (users: UserSeed[], faker: FakerLike): CapsuleSeed[] => {
+  const capsules: CapsuleSeed[] = [];
+
+  for (let index = 0; index < TOTAL_CAPSULES; index += 1) {
+    const owner = users[index % users.length];
+    const status = resolveCapsuleStatus(index);
+    const objectId = buildObjectId(5000 + index);
+
+    capsules.push({
+      _id: objectId,
+      id: objectId.toHexString(),
+      ownerId: owner.id,
+      title: faker.lorem.sentence().slice(0, 100),
+      message: index % 7 === 0 ? null : faker.lorem.paragraph(),
+      unlockDate: resolveUnlockDate(status, index),
+      status,
+      createdAt: addDays(-(90 - index)),
+      updatedAt: addDays(-(15 - (index % 15))),
+    });
+  }
+
+  return capsules;
+};
+
+const seed = async () => {
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    throw new Error('MONGO_URI is not defined');
+  }
+
+  const teardown = process.argv.includes('--teardown');
+  const faker = await loadFaker();
+  faker.seed(424242);
+
+  await mongoose.connect(mongoUri);
+
+  const usersCollection = mongoose.connection.collection('users');
+  const capsulesCollection = mongoose.connection.collection('capsules');
+
+  if (teardown) {
+    await Promise.all([
+      usersCollection.deleteMany({}),
+      capsulesCollection.deleteMany({}),
+    ]);
+    console.log('Teardown complete: cleared users and capsules.');
+  }
+
+  const users = buildUsers(faker);
+  const capsules = buildCapsules(users, faker);
+
+  await usersCollection.bulkWrite(
+    users.map((user) => ({
+      updateOne: {
+        filter: { _id: user._id },
+        update: { $set: user },
+        upsert: true,
+      },
+    })),
+  );
+
+  await capsulesCollection.bulkWrite(
+    capsules.map((capsule) => ({
+      updateOne: {
+        filter: { _id: capsule._id },
+        update: { $set: capsule },
+        upsert: true,
+      },
+    })),
+  );
+
+  const draftCount = capsules.filter((capsule) => capsule.status === 'DRAFT').length;
+  const draftNullUnlockDateCount = capsules.filter(
+    (capsule) => capsule.status === 'DRAFT' && capsule.unlockDate === null,
+  ).length;
+  const draftFutureUnlockDateCount = capsules.filter(
+    (capsule) =>
+      capsule.status === 'DRAFT' &&
+      capsule.unlockDate !== null &&
+      capsule.unlockDate.getTime() > Date.now(),
+  ).length;
+
+  console.log(`Seed complete: users=${users.length}, capsules=${capsules.length}`);
+  console.log(
+    `Draft mix: total=${draftCount}, nullUnlockDate=${draftNullUnlockDateCount}, futureUnlockDate=${draftFutureUnlockDateCount}`,
+  );
+};
+
+seed()
+  .catch((error: unknown) => {
+    console.error('Seeding failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await mongoose.disconnect();
+  });

--- a/apps/api/tsconfig.scripts.json
+++ b/apps/api/tsconfig.scripts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["scripts/**/*.ts", "src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@faker-js/faker':
+        specifier: ^10.3.0
+        version: 10.3.0
       '@ourkairos/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -280,6 +283,10 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@faker-js/faker@10.3.0':
+    resolution: {integrity: sha512-It0Sne6P3szg7JIi6CgKbvTZoMjxBZhcv91ZrqrNuaZQfB5WoqYYbzCUOq89YR+VY8juY9M1vDWmDDa2TzfXCw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2745,6 +2752,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@faker-js/faker@10.3.0': {}
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
Add a TypeScript seeding script to populate MongoDB with sample users and capsules for local/dev use. Introduces scripts/seed.ts with deterministic fake data (uses @faker-js/faker), a tsconfig.scripts.json for running ts-node, and package.json scripts: "seed" and "seed:teardown". Also adds @faker-js/faker to devDependencies and updates the pnpm lockfile. The seed script expects MONGO_URI in the environment and supports --teardown to clear seeded collections.
closes #265 