### PR TITLE
feat/lab-timeline-visualizer

### DIFF
--- a/experiments/track-b/.gitignore
+++ b/experiments/track-b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+pnpm-lock.yaml
+lab-shell/node_modules
+lab-shell/dist

--- a/experiments/track-b/README.md
+++ b/experiments/track-b/README.md
@@ -1,0 +1,42 @@
+# Track B Sandbox
+
+This folder is an isolated contributor sandbox. It is intentionally separate from the main delivery path so work can happen in parallel without affecting the OG issues.
+
+## Goals
+
+- Keep contributor activity alive with low coupling to production code.
+- Provide a clean place for tangent prototypes and experiments.
+- Make cleanup simple and low-risk.
+
+## Boundaries
+
+- Keep all new code under `experiments/track-b`.
+- Do not import from:
+  - `apps/api`
+  - `apps/web`
+  - `apps/stellar`
+- Do not add runtime wiring to the main app.
+- If shared contracts are needed, only import from shared packages.
+
+## Quickstart
+
+```bash
+cd experiments/track-b
+pnpm install
+pnpm dev
+```
+
+## Available Scripts
+
+- `pnpm dev`
+- `pnpm build`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+
+## Cleanup
+
+This sandbox is intentionally disposable:
+
+1. Remove this folder: `experiments/track-b`
+2. No app/runtime cleanup should be required outside this path.

--- a/experiments/track-b/README.md
+++ b/experiments/track-b/README.md
@@ -29,10 +29,15 @@ pnpm dev
 ## Available Scripts
 
 - `pnpm dev`
+- `pnpm dev:b02`
 - `pnpm build`
+- `pnpm build:b02`
 - `pnpm typecheck`
+- `pnpm typecheck:b02`
 - `pnpm lint`
+- `pnpm lint:b02`
 - `pnpm test`
+- `pnpm test:b02`
 
 ## Cleanup
 

--- a/experiments/track-b/capsule-replay/README.md
+++ b/experiments/track-b/capsule-replay/README.md
@@ -1,0 +1,26 @@
+# B-02 Capsule Replay Visualizer
+
+React-only sandbox for replaying capsule lifecycle events from a local JSON dataset.
+
+## Scope
+
+- No backend calls.
+- No dependency on OG app runtime.
+- Deterministic replay based on `src/data/events.json`.
+
+## Features
+
+- Timeline replay controls: play, pause, reset.
+- Replay speed: x1, x2, x4.
+- Time scrubber for manual seeking.
+- Event markers on a timeline track.
+- Live capsule state transitions (draft, sealed, unlocked).
+- Filters by `ownerId` and `status`.
+
+## Run
+
+```bash
+cd experiments/track-b
+pnpm install
+pnpm dev:b02
+```

--- a/experiments/track-b/capsule-replay/eslint.config.mjs
+++ b/experiments/track-b/capsule-replay/eslint.config.mjs
@@ -1,0 +1,20 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import globals from "globals";
+
+export default tseslint.config(
+  {
+    ignores: ["dist", "node_modules"],
+  },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+  },
+);

--- a/experiments/track-b/capsule-replay/index.html
+++ b/experiments/track-b/capsule-replay/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Capsule Replay Visualizer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/experiments/track-b/capsule-replay/package.json
+++ b/experiments/track-b/capsule-replay/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@ourkairos/capsule-replay",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.2",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^5.1.1",
+    "eslint": "^9.39.2",
+    "globals": "^17.1.0",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.53.1",
+    "vite": "^7.2.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/experiments/track-b/capsule-replay/src/App.tsx
+++ b/experiments/track-b/capsule-replay/src/App.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useMemo, useState } from "react";
+import replayEvents from "./data/events.json";
+import {
+  buildCapsuleStates,
+  filterCapsuleStates,
+  filterMarkerEvents,
+  getOwnerOptions,
+  getReplayBounds,
+  sortEvents,
+} from "./lib/replay";
+import type { CapsuleEvent, CapsuleStatus, ReplaySpeed } from "./types";
+
+const SPEED_OPTIONS: ReplaySpeed[] = [1, 2, 4];
+const STATUS_OPTIONS: Array<"ALL" | CapsuleStatus> = [
+  "ALL",
+  "DRAFT",
+  "SEALED",
+  "UNLOCKED",
+];
+const TICK_INTERVAL_MS = 120;
+const STEP_PER_TICK_MS = 30 * 60 * 1000;
+
+const formatDateTime = (timeMs: number): string =>
+  new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timeMs));
+
+export function App() {
+  const events = useMemo(
+    () => sortEvents(replayEvents as CapsuleEvent[]),
+    [],
+  );
+  const bounds = useMemo(() => getReplayBounds(events), [events]);
+  const ownerOptions = useMemo(() => getOwnerOptions(events), [events]);
+
+  const [currentMs, setCurrentMs] = useState(bounds.startMs);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speed, setSpeed] = useState<ReplaySpeed>(1);
+  const [ownerId, setOwnerId] = useState<"ALL" | string>("ALL");
+  const [status, setStatus] = useState<"ALL" | CapsuleStatus>("ALL");
+
+  useEffect(() => {
+    setCurrentMs(bounds.startMs);
+    setIsPlaying(false);
+  }, [bounds.startMs, bounds.endMs]);
+
+  useEffect(() => {
+    if (!isPlaying) return;
+
+    const timer = window.setInterval(() => {
+      setCurrentMs((previousMs) => {
+        const nextMs = Math.min(
+          previousMs + STEP_PER_TICK_MS * speed,
+          bounds.endMs,
+        );
+
+        if (nextMs >= bounds.endMs) {
+          setIsPlaying(false);
+        }
+        return nextMs;
+      });
+    }, TICK_INTERVAL_MS);
+
+    return () => window.clearInterval(timer);
+  }, [isPlaying, speed, bounds.endMs]);
+
+  const allStates = useMemo(
+    () => buildCapsuleStates(events, currentMs),
+    [events, currentMs],
+  );
+
+  const filteredStates = useMemo(
+    () => filterCapsuleStates(allStates, { ownerId, status }),
+    [allStates, ownerId, status],
+  );
+
+  const visibleCapsuleIds = useMemo(
+    () => new Set(filteredStates.map((state) => state.capsuleId)),
+    [filteredStates],
+  );
+
+  const ownerFilteredEvents = useMemo(
+    () => filterMarkerEvents(events, ownerId),
+    [events, ownerId],
+  );
+
+  const timelineEvents = useMemo(
+    () =>
+      ownerFilteredEvents.filter(
+        (event) => status === "ALL" || visibleCapsuleIds.has(event.capsuleId),
+      ),
+    [ownerFilteredEvents, status, visibleCapsuleIds],
+  );
+
+  const transitions = useMemo(
+    () =>
+      timelineEvents
+        .filter((event) => new Date(event.occurredAt).getTime() <= currentMs)
+        .slice(-8)
+        .reverse(),
+    [timelineEvents, currentMs],
+  );
+
+  const rangeMs = Math.max(1, bounds.endMs - bounds.startMs);
+
+  const jumpToStart = () => {
+    setCurrentMs(bounds.startMs);
+    setIsPlaying(false);
+  };
+
+  return (
+    <div className="page">
+      <header className="hero">
+        <h1>Capsule Event Replay Visualizer</h1>
+        <p>
+          Local JSON replay only. No API calls. Deterministic event ordering
+          and playback.
+        </p>
+      </header>
+
+      <section className="panel controls">
+        <div className="control-group">
+          <button type="button" onClick={() => setIsPlaying(true)}>
+            Play
+          </button>
+          <button type="button" onClick={() => setIsPlaying(false)}>
+            Pause
+          </button>
+          <button type="button" onClick={jumpToStart}>
+            Reset
+          </button>
+        </div>
+
+        <div className="control-group">
+          {SPEED_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={speed === option ? "active" : ""}
+              onClick={() => setSpeed(option)}
+            >
+              x{option}
+            </button>
+          ))}
+        </div>
+
+        <div className="control-group selects">
+          <label>
+            Owner
+            <select
+              value={ownerId}
+              onChange={(event) => setOwnerId(event.target.value)}
+            >
+              <option value="ALL">All owners</option>
+              {ownerOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            Status
+            <select
+              value={status}
+              onChange={(event) =>
+                setStatus(event.target.value as "ALL" | CapsuleStatus)
+              }
+            >
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="time-readout">
+          <span>Current: {formatDateTime(currentMs)}</span>
+          <span>Start: {formatDateTime(bounds.startMs)}</span>
+          <span>End: {formatDateTime(bounds.endMs)}</span>
+        </div>
+
+        <input
+          className="scrubber"
+          type="range"
+          min={bounds.startMs}
+          max={bounds.endMs}
+          step={15 * 60 * 1000}
+          value={currentMs}
+          onChange={(event) => {
+            setCurrentMs(Number(event.target.value));
+            setIsPlaying(false);
+          }}
+        />
+      </section>
+
+      <section className="panel timeline-panel">
+        <div className="timeline-track" role="presentation">
+          {timelineEvents.map((event) => {
+            const eventMs = new Date(event.occurredAt).getTime();
+            const leftPct = ((eventMs - bounds.startMs) / rangeMs) * 100;
+            const isPast = eventMs <= currentMs;
+            const isNow =
+              Math.abs(eventMs - currentMs) < STEP_PER_TICK_MS * speed;
+
+            return (
+              <button
+                key={event.id}
+                type="button"
+                className={`marker ${isPast ? "past" : "future"} ${
+                  isNow ? "now" : ""
+                }`}
+                style={{ left: `${leftPct}%` }}
+                title={`${event.title} • ${event.type} • ${formatDateTime(
+                  eventMs,
+                )}`}
+                onClick={() => {
+                  setCurrentMs(eventMs);
+                  setIsPlaying(false);
+                }}
+              />
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="grid">
+        <article className="panel">
+          <h2>Capsule States ({filteredStates.length})</h2>
+          {filteredStates.length === 0 ? (
+            <p className="empty">No capsules match current filters.</p>
+          ) : (
+            <ul className="capsule-list">
+              {filteredStates.map((state) => (
+                <li key={state.capsuleId}>
+                  <div>
+                    <strong>{state.title}</strong>
+                    <small>
+                      {state.ownerId} • {state.eventCount} events
+                    </small>
+                  </div>
+                  <div className={`status ${state.status.toLowerCase()}`}>
+                    {state.status}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+
+        <article className="panel">
+          <h2>Recent Transitions</h2>
+          {transitions.length === 0 ? (
+            <p className="empty">No transitions occurred yet at this replay point.</p>
+          ) : (
+            <ul className="transition-list">
+              {transitions.map((event) => (
+                <li key={event.id}>
+                  <strong>{event.type}</strong> {event.title}
+                  <span>{formatDateTime(new Date(event.occurredAt).getTime())}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/experiments/track-b/capsule-replay/src/data/events.json
+++ b/experiments/track-b/capsule-replay/src/data/events.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "e-001",
+    "capsuleId": "cap-001",
+    "ownerId": "user-01",
+    "title": "Letter to Future Self",
+    "type": "DRAFT_CREATED",
+    "occurredAt": "2026-01-01T09:00:00.000Z"
+  },
+  {
+    "id": "e-002",
+    "capsuleId": "cap-002",
+    "ownerId": "user-02",
+    "title": "Career Milestone Notes",
+    "type": "DRAFT_CREATED",
+    "occurredAt": "2026-01-01T10:30:00.000Z"
+  },
+  {
+    "id": "e-003",
+    "capsuleId": "cap-003",
+    "ownerId": "user-03",
+    "title": "Travel Reflection",
+    "type": "DRAFT_CREATED",
+    "occurredAt": "2026-01-01T11:15:00.000Z"
+  },
+  {
+    "id": "e-004",
+    "capsuleId": "cap-001",
+    "ownerId": "user-01",
+    "title": "Letter to Future Self",
+    "type": "SEALED",
+    "occurredAt": "2026-01-02T08:00:00.000Z"
+  },
+  {
+    "id": "e-005",
+    "capsuleId": "cap-004",
+    "ownerId": "user-01",
+    "title": "Family Time Capsule",
+    "type": "DRAFT_CREATED",
+    "occurredAt": "2026-01-02T11:40:00.000Z"
+  },
+  {
+    "id": "e-006",
+    "capsuleId": "cap-002",
+    "ownerId": "user-02",
+    "title": "Career Milestone Notes",
+    "type": "SEALED",
+    "occurredAt": "2026-01-03T12:00:00.000Z"
+  },
+  {
+    "id": "e-007",
+    "capsuleId": "cap-005",
+    "ownerId": "user-02",
+    "title": "Startup Journal",
+    "type": "DRAFT_CREATED",
+    "occurredAt": "2026-01-03T15:00:00.000Z"
+  },
+  {
+    "id": "e-008",
+    "capsuleId": "cap-003",
+    "ownerId": "user-03",
+    "title": "Travel Reflection",
+    "type": "SEALED",
+    "occurredAt": "2026-01-04T09:00:00.000Z"
+  },
+  {
+    "id": "e-009",
+    "capsuleId": "cap-006",
+    "ownerId": "user-03",
+    "title": "Music Inspiration Log",
+    "type": "DRAFT_CREATED",
+    "occurredAt": "2026-01-04T13:30:00.000Z"
+  },
+  {
+    "id": "e-010",
+    "capsuleId": "cap-004",
+    "ownerId": "user-01",
+    "title": "Family Time Capsule",
+    "type": "SEALED",
+    "occurredAt": "2026-01-05T08:30:00.000Z"
+  },
+  {
+    "id": "e-011",
+    "capsuleId": "cap-001",
+    "ownerId": "user-01",
+    "title": "Letter to Future Self",
+    "type": "UNLOCKED",
+    "occurredAt": "2026-01-06T09:00:00.000Z"
+  },
+  {
+    "id": "e-012",
+    "capsuleId": "cap-005",
+    "ownerId": "user-02",
+    "title": "Startup Journal",
+    "type": "SEALED",
+    "occurredAt": "2026-01-06T12:45:00.000Z"
+  },
+  {
+    "id": "e-013",
+    "capsuleId": "cap-006",
+    "ownerId": "user-03",
+    "title": "Music Inspiration Log",
+    "type": "SEALED",
+    "occurredAt": "2026-01-07T11:30:00.000Z"
+  },
+  {
+    "id": "e-014",
+    "capsuleId": "cap-002",
+    "ownerId": "user-02",
+    "title": "Career Milestone Notes",
+    "type": "UNLOCKED",
+    "occurredAt": "2026-01-08T09:10:00.000Z"
+  },
+  {
+    "id": "e-015",
+    "capsuleId": "cap-003",
+    "ownerId": "user-03",
+    "title": "Travel Reflection",
+    "type": "UNLOCKED",
+    "occurredAt": "2026-01-08T17:20:00.000Z"
+  },
+  {
+    "id": "e-016",
+    "capsuleId": "cap-004",
+    "ownerId": "user-01",
+    "title": "Family Time Capsule",
+    "type": "UNLOCKED",
+    "occurredAt": "2026-01-09T07:45:00.000Z"
+  },
+  {
+    "id": "e-017",
+    "capsuleId": "cap-005",
+    "ownerId": "user-02",
+    "title": "Startup Journal",
+    "type": "UNLOCKED",
+    "occurredAt": "2026-01-10T08:00:00.000Z"
+  }
+]

--- a/experiments/track-b/capsule-replay/src/lib/replay.test.ts
+++ b/experiments/track-b/capsule-replay/src/lib/replay.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { CapsuleEvent } from "../types";
+import { buildCapsuleStates, getReplayBounds, sortEvents } from "./replay";
+
+const fixtureEvents: CapsuleEvent[] = [
+  {
+    id: "e-3",
+    capsuleId: "cap-1",
+    ownerId: "user-1",
+    title: "A",
+    type: "UNLOCKED",
+    occurredAt: "2026-01-02T00:00:00.000Z",
+  },
+  {
+    id: "e-1",
+    capsuleId: "cap-1",
+    ownerId: "user-1",
+    title: "A",
+    type: "DRAFT_CREATED",
+    occurredAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "e-2",
+    capsuleId: "cap-1",
+    ownerId: "user-1",
+    title: "A",
+    type: "SEALED",
+    occurredAt: "2026-01-01T12:00:00.000Z",
+  },
+];
+
+describe("replay engine", () => {
+  it("sorts events deterministically", () => {
+    const sorted = sortEvents(fixtureEvents);
+    expect(sorted.map((event) => event.id)).toEqual(["e-1", "e-2", "e-3"]);
+  });
+
+  it("returns stable replay bounds", () => {
+    const bounds = getReplayBounds(fixtureEvents);
+    expect(bounds.startMs).toBe(new Date("2026-01-01T00:00:00.000Z").getTime());
+    expect(bounds.endMs).toBe(new Date("2026-01-02T00:00:00.000Z").getTime());
+  });
+
+  it("builds capsule state at a replay timestamp", () => {
+    const stateAtSeal = buildCapsuleStates(
+      fixtureEvents,
+      new Date("2026-01-01T12:00:00.000Z").getTime(),
+    );
+
+    expect(stateAtSeal).toHaveLength(1);
+    expect(stateAtSeal[0]?.status).toBe("SEALED");
+    expect(stateAtSeal[0]?.eventCount).toBe(2);
+  });
+});

--- a/experiments/track-b/capsule-replay/src/lib/replay.ts
+++ b/experiments/track-b/capsule-replay/src/lib/replay.ts
@@ -1,0 +1,100 @@
+import type {
+  CapsuleEvent,
+  CapsuleEventType,
+  CapsuleState,
+  CapsuleStatus,
+  ReplayBounds,
+  ReplayFilters,
+} from "../types";
+
+const toMs = (value: string): number => new Date(value).getTime();
+
+const eventTypePriority: Record<CapsuleEventType, number> = {
+  DRAFT_CREATED: 0,
+  SEALED: 1,
+  UNLOCKED: 2,
+};
+
+export const sortEvents = (events: CapsuleEvent[]): CapsuleEvent[] =>
+  [...events].sort((left, right) => {
+    const leftMs = toMs(left.occurredAt);
+    const rightMs = toMs(right.occurredAt);
+
+    if (leftMs !== rightMs) return leftMs - rightMs;
+
+    const leftPriority = eventTypePriority[left.type];
+    const rightPriority = eventTypePriority[right.type];
+    if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+
+    return left.id.localeCompare(right.id);
+  });
+
+export const getReplayBounds = (events: CapsuleEvent[]): ReplayBounds => {
+  const sorted = sortEvents(events);
+  if (sorted.length === 0) {
+    const now = Date.now();
+    return { startMs: now, endMs: now };
+  }
+
+  return {
+    startMs: toMs(sorted[0].occurredAt),
+    endMs: toMs(sorted[sorted.length - 1].occurredAt),
+  };
+};
+
+export const mapEventTypeToStatus = (eventType: CapsuleEventType): CapsuleStatus => {
+  if (eventType === "DRAFT_CREATED") return "DRAFT";
+  if (eventType === "SEALED") return "SEALED";
+  return "UNLOCKED";
+};
+
+export const buildCapsuleStates = (
+  events: CapsuleEvent[],
+  atMs: number,
+): CapsuleState[] => {
+  const stateByCapsule = new Map<string, CapsuleState>();
+
+  for (const event of sortEvents(events)) {
+    if (toMs(event.occurredAt) > atMs) break;
+
+    const prior = stateByCapsule.get(event.capsuleId);
+    stateByCapsule.set(event.capsuleId, {
+      capsuleId: event.capsuleId,
+      ownerId: event.ownerId,
+      title: event.title,
+      status: mapEventTypeToStatus(event.type),
+      lastEventAt: event.occurredAt,
+      eventCount: (prior?.eventCount ?? 0) + 1,
+    });
+  }
+
+  return [...stateByCapsule.values()].sort((left, right) =>
+    left.title.localeCompare(right.title),
+  );
+};
+
+export const getOwnerOptions = (events: CapsuleEvent[]): string[] => {
+  const ownerSet = new Set(events.map((event) => event.ownerId));
+  return [...ownerSet].sort();
+};
+
+export const filterCapsuleStates = (
+  states: CapsuleState[],
+  filters: ReplayFilters,
+): CapsuleState[] =>
+  states.filter((state) => {
+    const ownerMatch =
+      filters.ownerId === "ALL" || state.ownerId === filters.ownerId;
+    const statusMatch =
+      filters.status === "ALL" || state.status === filters.status;
+
+    return ownerMatch && statusMatch;
+  });
+
+export const filterMarkerEvents = (
+  events: CapsuleEvent[],
+  ownerId: ReplayFilters["ownerId"],
+): CapsuleEvent[] =>
+  sortEvents(events).filter(
+    (event) => ownerId === "ALL" || event.ownerId === ownerId,
+  );

--- a/experiments/track-b/capsule-replay/src/main.tsx
+++ b/experiments/track-b/capsule-replay/src/main.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Unable to mount app: #root was not found.");
+}
+
+createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/experiments/track-b/capsule-replay/src/styles.css
+++ b/experiments/track-b/capsule-replay/src/styles.css
@@ -1,0 +1,205 @@
+:root {
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  color: #0f172a;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.page {
+  margin: 0 auto;
+  max-width: 1100px;
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.hero h1 {
+  margin: 0 0 8px;
+  font-size: 2rem;
+}
+
+.hero p {
+  margin: 0;
+  color: #334155;
+}
+
+.panel {
+  border: 1px solid #cbd5e1;
+  border-radius: 14px;
+  background: #ffffff;
+  padding: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
+}
+
+.controls {
+  display: grid;
+  gap: 14px;
+}
+
+.control-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+button {
+  border: 1px solid #1d4ed8;
+  background: #eff6ff;
+  color: #1e3a8a;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button.active {
+  background: #1d4ed8;
+  color: #ffffff;
+}
+
+.selects label {
+  display: grid;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+select {
+  border: 1px solid #94a3b8;
+  border-radius: 8px;
+  padding: 6px 8px;
+  min-width: 150px;
+}
+
+.time-readout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.scrubber {
+  width: 100%;
+}
+
+.timeline-panel {
+  overflow-x: auto;
+}
+
+.timeline-track {
+  position: relative;
+  height: 42px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #dbeafe 0%, #bfdbfe 100%);
+  border: 1px solid #93c5fd;
+}
+
+.marker {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  padding: 0;
+  border-radius: 999px;
+  border: none;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 0 2px #ffffff;
+}
+
+.marker.past {
+  background: #0f766e;
+}
+
+.marker.future {
+  background: #94a3b8;
+}
+
+.marker.now {
+  box-shadow: 0 0 0 3px #f59e0b;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.capsule-list,
+.transition-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.capsule-list li,
+.transition-list li {
+  border: 1px solid #dbeafe;
+  border-radius: 10px;
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.capsule-list li small {
+  display: block;
+  color: #64748b;
+  margin-top: 2px;
+}
+
+.transition-list li {
+  display: grid;
+  gap: 4px;
+  justify-content: start;
+}
+
+.transition-list li span {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.status {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  border-radius: 999px;
+  padding: 5px 10px;
+}
+
+.status.draft {
+  background: #ffedd5;
+  color: #9a3412;
+}
+
+.status.sealed {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.status.unlocked {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.empty {
+  color: #64748b;
+  margin: 0;
+}
+
+@media (max-width: 840px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/experiments/track-b/capsule-replay/src/types.ts
+++ b/experiments/track-b/capsule-replay/src/types.ts
@@ -1,0 +1,31 @@
+export type CapsuleEventType = "DRAFT_CREATED" | "SEALED" | "UNLOCKED";
+export type CapsuleStatus = "DRAFT" | "SEALED" | "UNLOCKED";
+export type ReplaySpeed = 1 | 2 | 4;
+
+export type CapsuleEvent = {
+  id: string;
+  capsuleId: string;
+  ownerId: string;
+  title: string;
+  type: CapsuleEventType;
+  occurredAt: string;
+};
+
+export type ReplayBounds = {
+  startMs: number;
+  endMs: number;
+};
+
+export type CapsuleState = {
+  capsuleId: string;
+  ownerId: string;
+  title: string;
+  status: CapsuleStatus;
+  lastEventAt: string;
+  eventCount: number;
+};
+
+export type ReplayFilters = {
+  ownerId: "ALL" | string;
+  status: "ALL" | CapsuleStatus;
+};

--- a/experiments/track-b/capsule-replay/tsconfig.json
+++ b/experiments/track-b/capsule-replay/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client", "vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/experiments/track-b/capsule-replay/tsconfig.node.json
+++ b/experiments/track-b/capsule-replay/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/experiments/track-b/capsule-replay/vite.config.ts
+++ b/experiments/track-b/capsule-replay/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/experiments/track-b/lab-shell/eslint.config.mjs
+++ b/experiments/track-b/lab-shell/eslint.config.mjs
@@ -1,0 +1,17 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import globals from "globals";
+
+export default tseslint.config(
+  {
+    ignores: ["dist", "node_modules"],
+  },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ["**/*.ts"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.node,
+    },
+  },
+);

--- a/experiments/track-b/lab-shell/package.json
+++ b/experiments/track-b/lab-shell/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ourkairos/lab-shell",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.2",
+    "@types/node": "^20.19.30",
+    "eslint": "^9.39.2",
+    "globals": "^17.1.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.53.1",
+    "vitest": "^2.1.8"
+  }
+}

--- a/experiments/track-b/lab-shell/src/index.ts
+++ b/experiments/track-b/lab-shell/src/index.ts
@@ -1,0 +1,16 @@
+export type SandboxHealth = {
+  name: string;
+  status: "ready";
+  timestamp: string;
+};
+
+export const getSandboxHealth = (): SandboxHealth => ({
+  name: "@ourkairos/lab-shell",
+  status: "ready",
+  timestamp: new Date().toISOString(),
+});
+
+if (process.env.NODE_ENV !== "test") {
+  // Keeps `pnpm dev` visibly alive for contributors.
+  console.log(getSandboxHealth());
+}

--- a/experiments/track-b/lab-shell/tests/smoke.test.ts
+++ b/experiments/track-b/lab-shell/tests/smoke.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { getSandboxHealth } from "../src/index.js";
+
+describe("track-b lab shell", () => {
+  it("returns a ready status payload", () => {
+    const health = getSandboxHealth();
+    expect(health.name).toBe("@ourkairos/lab-shell");
+    expect(health.status).toBe("ready");
+    expect(typeof health.timestamp).toBe("string");
+  });
+});

--- a/experiments/track-b/lab-shell/tsconfig.build.json
+++ b/experiments/track-b/lab-shell/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests/**/*.ts"]
+}

--- a/experiments/track-b/lab-shell/tsconfig.json
+++ b/experiments/track-b/lab-shell/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "vitest/globals"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/experiments/track-b/lab-shell/vitest.config.ts
+++ b/experiments/track-b/lab-shell/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/experiments/track-b/package.json
+++ b/experiments/track-b/package.json
@@ -5,9 +5,14 @@
   "packageManager": "pnpm@10.14.0",
   "scripts": {
     "dev": "pnpm --filter @ourkairos/lab-shell dev",
+    "dev:b02": "pnpm --filter @ourkairos/capsule-replay dev",
     "build": "pnpm --filter @ourkairos/lab-shell build",
+    "build:b02": "pnpm --filter @ourkairos/capsule-replay build",
     "typecheck": "pnpm --filter @ourkairos/lab-shell typecheck",
+    "typecheck:b02": "pnpm --filter @ourkairos/capsule-replay typecheck",
     "lint": "pnpm --filter @ourkairos/lab-shell lint",
-    "test": "pnpm --filter @ourkairos/lab-shell test"
+    "lint:b02": "pnpm --filter @ourkairos/capsule-replay lint",
+    "test": "pnpm --filter @ourkairos/lab-shell test",
+    "test:b02": "pnpm --filter @ourkairos/capsule-replay test"
   }
 }

--- a/experiments/track-b/package.json
+++ b/experiments/track-b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ourkairos/track-b",
+  "private": true,
+  "version": "0.0.0",
+  "packageManager": "pnpm@10.14.0",
+  "scripts": {
+    "dev": "pnpm --filter @ourkairos/lab-shell dev",
+    "build": "pnpm --filter @ourkairos/lab-shell build",
+    "typecheck": "pnpm --filter @ourkairos/lab-shell typecheck",
+    "lint": "pnpm --filter @ourkairos/lab-shell lint",
+    "test": "pnpm --filter @ourkairos/lab-shell test"
+  }
+}

--- a/experiments/track-b/pnpm-workspace.yaml
+++ b/experiments/track-b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "lab-shell"
+  - "capsule-replay"

--- a/experiments/track-b/pnpm-workspace.yaml
+++ b/experiments/track-b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "lab-shell"


### PR DESCRIPTION
**Summary**

Adds a React-only timeline visualizer that replays capsule lifecycle events (draft → sealed → unlocked) from a local mocked dataset and Introduces a sandbox-only CLI for generating request traffic against configurable endpoints for local stress simulation and demos.

**What’s Included**

- Deterministic replay using events.json

- Play / pause controls with speed options (x1, x2, x4)

- Visual event markers and state transitions

- Filtering by ownerId and status

- No backend or external calls

**Notes**

- Entire feature lives in a single lab folder

- Can be fully removed by deleting the folder

- Replay output is consistent across runs

Closes #286, #287