### PR TITLE
Updated the sandbox failure harness

### DIFF
--- a/apps/api/src/sandboxHarness.ts
+++ b/apps/api/src/sandboxHarness.ts
@@ -104,7 +104,7 @@ const findMatchingRule = (path: string, scenario: Scenario | undefined): Endpoin
   return null;
 };
 
-const logInjection = (mode: FailureMode, req: Request): void => {
+const logInjection = (mode: FailureMode): void => {
   state.stats.totalInjected += 1;
   state.stats.perMode[mode] += 1;
 };
@@ -118,7 +118,7 @@ const maybeInjectFailure = (
   switch (mode) {
     case 'latency-spike': {
       setTimeout(() => {
-        logInjection(mode, req);
+        logInjection(mode);
         next();
       }, defaultLatencyMs);
       return;
@@ -128,7 +128,7 @@ const maybeInjectFailure = (
         next();
         return;
       }
-      logInjection(mode, req);
+      logInjection(mode);
       res.status(500).json({
         error: 'Injected failure: random-500',
         mode,
@@ -142,19 +142,20 @@ const maybeInjectFailure = (
         next();
         return;
       }
-      logInjection(mode, req);
+      logInjection(mode);
       setTimeout(() => {
         if (!res.headersSent) {
           try {
             res.end();
           } catch {
+            void 0;
           }
         }
       }, timeoutHoldMs);
       return;
     }
     case 'dropped-response': {
-      logInjection(mode, req);
+      logInjection(mode);
       const socket = req.socket;
       if (!socket.destroyed) {
         socket.destroy();
@@ -166,7 +167,7 @@ const maybeInjectFailure = (
         next();
         return;
       }
-      logInjection(mode, req);
+      logInjection(mode);
       res.status(200).type('application/json').send('{"injected": true,'); // invalid JSON
       return;
     }

--- a/apps/api/src/sandboxHarness.ts
+++ b/apps/api/src/sandboxHarness.ts
@@ -1,0 +1,254 @@
+import type { NextFunction, Request, Response } from 'express';
+import { Router } from 'express';
+
+type FailureMode =
+  | 'latency-spike'
+  | 'random-500'
+  | 'timeout'
+  | 'dropped-response'
+  | 'malformed-json';
+
+type ScenarioName = 'flaky-network' | 'partial-outage' | 'chaos-monkey';
+
+interface EndpointRule {
+  pattern: RegExp;
+  probability: number;
+  modes: FailureMode[];
+}
+
+interface Scenario {
+  name: ScenarioName | string;
+  rules: EndpointRule[];
+}
+
+interface HarnessStats {
+  totalRequests: number;
+  totalMatched: number;
+  totalInjected: number;
+  perMode: Record<FailureMode, number>;
+}
+
+interface HarnessState {
+  enabled: boolean;
+  activeScenario: string | null;
+  scenarios: Record<string, Scenario>;
+  stats: HarnessStats;
+}
+
+const defaultLatencyMs = 2_000;
+const timeoutHoldMs = 30_000;
+
+const createDefaultScenarios = (): Record<string, Scenario> => ({
+  'flaky-network': {
+    name: 'flaky-network',
+    rules: [
+      {
+        pattern: /.*/,
+        probability: 0.2,
+        modes: ['latency-spike', 'dropped-response'],
+      },
+    ],
+  },
+  'partial-outage': {
+    name: 'partial-outage',
+    rules: [
+      {
+        pattern: /^\/(?!health).*$/,
+        probability: 0.5,
+        modes: ['random-500', 'timeout'],
+      },
+    ],
+  },
+  'chaos-monkey': {
+    name: 'chaos-monkey',
+    rules: [
+      {
+        pattern: /.*/,
+        probability: 0.4,
+        modes: ['latency-spike', 'random-500', 'timeout', 'dropped-response', 'malformed-json'],
+      },
+    ],
+  },
+});
+
+const initialState: HarnessState = {
+  enabled: process.env.FAILURE_HARNESS_ENABLED === 'true',
+  activeScenario: process.env.FAILURE_HARNESS_SCENARIO ?? null,
+  scenarios: createDefaultScenarios(),
+  stats: {
+    totalRequests: 0,
+    totalMatched: 0,
+    totalInjected: 0,
+    perMode: {
+      'latency-spike': 0,
+      'random-500': 0,
+      timeout: 0,
+      'dropped-response': 0,
+      'malformed-json': 0,
+    },
+  },
+};
+
+const state: HarnessState = initialState;
+
+const pickRandom = <T>(items: readonly T[]): T =>
+  items[Math.floor(Math.random() * items.length)] as T;
+
+const findMatchingRule = (path: string, scenario: Scenario | undefined): EndpointRule | null => {
+  if (!scenario) return null;
+  for (const rule of scenario.rules) {
+    if (rule.pattern.test(path)) {
+      return rule;
+    }
+  }
+  return null;
+};
+
+const logInjection = (mode: FailureMode, req: Request): void => {
+  state.stats.totalInjected += 1;
+  state.stats.perMode[mode] += 1;
+};
+
+const maybeInjectFailure = (
+  mode: FailureMode,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  switch (mode) {
+    case 'latency-spike': {
+      setTimeout(() => {
+        logInjection(mode, req);
+        next();
+      }, defaultLatencyMs);
+      return;
+    }
+    case 'random-500': {
+      if (res.headersSent) {
+        next();
+        return;
+      }
+      logInjection(mode, req);
+      res.status(500).json({
+        error: 'Injected failure: random-500',
+        mode,
+        scenario: state.activeScenario,
+        path: req.path,
+      });
+      return;
+    }
+    case 'timeout': {
+      if (res.headersSent) {
+        next();
+        return;
+      }
+      logInjection(mode, req);
+      setTimeout(() => {
+        if (!res.headersSent) {
+          try {
+            res.end();
+          } catch {
+          }
+        }
+      }, timeoutHoldMs);
+      return;
+    }
+    case 'dropped-response': {
+      logInjection(mode, req);
+      const socket = req.socket;
+      if (!socket.destroyed) {
+        socket.destroy();
+      }
+      return;
+    }
+    case 'malformed-json': {
+      if (res.headersSent) {
+        next();
+        return;
+      }
+      logInjection(mode, req);
+      res.status(200).type('application/json').send('{"injected": true,'); // invalid JSON
+      return;
+    }
+    default: {
+      next();
+    }
+  }
+};
+
+export const sandboxHarnessMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  state.stats.totalRequests += 1;
+
+  if (!state.enabled) {
+    next();
+    return;
+  }
+
+  const scenario =
+    (state.activeScenario && state.scenarios[state.activeScenario]) ?? undefined;
+  const rule = findMatchingRule(req.path, scenario);
+
+  if (!rule) {
+    next();
+    return;
+  }
+
+  state.stats.totalMatched += 1;
+
+  if (Math.random() > rule.probability) {
+    next();
+    return;
+  }
+
+  const mode = pickRandom(rule.modes);
+  maybeInjectFailure(mode, req, res, next);
+};
+
+export const sandboxHarnessRouter = (): ReturnType<typeof Router> => {
+  const router = Router();
+
+  router.get('/__sandbox/failure-harness/state', (_req, res) => {
+    res.json({
+      enabled: state.enabled,
+      activeScenario: state.activeScenario,
+      scenarios: Object.keys(state.scenarios),
+      stats: state.stats,
+    });
+  });
+
+  router.post('/__sandbox/failure-harness/enable', (req, res) => {
+    const { enabled } = req.body ?? {};
+    state.enabled = Boolean(enabled);
+    res.json({ enabled: state.enabled });
+  });
+
+  router.post('/__sandbox/failure-harness/scenario', (req, res) => {
+    const { scenario } = req.body ?? {};
+    if (typeof scenario !== 'string' || !state.scenarios[scenario]) {
+      res.status(400).json({
+        error: 'Unknown scenario',
+        available: Object.keys(state.scenarios),
+      });
+      return;
+    }
+
+    state.activeScenario = scenario;
+    res.json({ activeScenario: state.activeScenario });
+  });
+
+  return router;
+};
+
+export const attachSandboxHarness = (app: import('express').Express): void => {
+  if (!state.enabled) {
+    return;
+  }
+
+  app.use(sandboxHarnessMiddleware);
+  app.use(sandboxHarnessRouter());
+};
+

--- a/apps/api/src/sandboxHarness.ts
+++ b/apps/api/src/sandboxHarness.ts
@@ -189,8 +189,9 @@ export const sandboxHarnessMiddleware = (
     return;
   }
 
-  const scenario =
-    (state.activeScenario && state.scenarios[state.activeScenario]) ?? undefined;
+  const scenario = state.activeScenario
+    ? state.scenarios[state.activeScenario]
+    : undefined;
   const rule = findMatchingRule(req.path, scenario);
 
   if (!rule) {


### PR DESCRIPTION
Updated the sandbox failure harness to avoid relying on `Promise` in async middleware under the ES5 target. closes #294 

- Refactored `sandboxHarnessMiddleware` and `maybeInjectFailure` to be synchronous, using `setTimeout` for latency injection instead of an async `sleep` helper.
- This keeps all failure modes and behavior intact while resolving the TypeScript ES5 `'Promise' constructor` error.