### PR TITLE
feat(track-b): add isolated UI lab with automated a11y checks

### DIFF
--- a/experiments/track-b/package.json
+++ b/experiments/track-b/package.json
@@ -19,6 +19,7 @@
     "test": "pnpm --filter @ourkairos/lab-shell test",
     "test:b02": "pnpm --filter @ourkairos/capsule-replay test",
     "test:b03": "pnpm --filter @ourkairos/traffic-harness test",
+    "test:b04": "pnpm --filter @ourkairos/ui-lab test",
     "run:b03": "pnpm --filter @ourkairos/traffic-harness run cli"
   }
 }

--- a/experiments/track-b/pnpm-workspace.yaml
+++ b/experiments/track-b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - "lab-shell"
   - "capsule-replay"
   - "traffic-harness"
+  - "ui-lab"

--- a/experiments/track-b/ui-lab/a11y-audit-report.md
+++ b/experiments/track-b/ui-lab/a11y-audit-report.md
@@ -1,0 +1,17 @@
+# UI Lab A11y Audit Summary
+
+## Modal
+✅ Passed (No violations)
+
+## Dropdown
+✅ Passed (No violations)
+
+## Tabs
+✅ Passed (No violations)
+
+## Form
+✅ Passed (No violations)
+
+## Toast
+✅ Passed (No violations)
+

--- a/experiments/track-b/ui-lab/package.json
+++ b/experiments/track-b/ui-lab/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ourkairos/ui-lab",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "axe-core": "^4.8.3",
+    "jsdom": "^24.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/experiments/track-b/ui-lab/src/components.tsx
+++ b/experiments/track-b/ui-lab/src/components.tsx
@@ -1,0 +1,150 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+export const Modal = ({ isOpen, onClose, title, children }: any) => {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const el = ref.current;
+        if (!el) return;
+
+        // Focus trap implementation
+        const focusable = Array.from(el.querySelectorAll<HTMLElement>(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        ));
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Tab') {
+                if (e.shiftKey) {
+                    if (document.activeElement === first) {
+                        e.preventDefault();
+                        last?.focus();
+                    }
+                } else {
+                    if (document.activeElement === last) {
+                        e.preventDefault();
+                        first?.focus();
+                    }
+                }
+            } else if (e.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        el.addEventListener('keydown', handleKeyDown);
+        first?.focus();
+        return () => el.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen, onClose]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div role="dialog" aria-modal="true" aria-labelledby="modal-title" ref={ref}>
+            <h2 id="modal-title">{title}</h2>
+            {children}
+            <button onClick={onClose} aria-label="Close modal">Close</button>
+        </div>
+    );
+};
+
+export const Dropdown = ({ options }: { options: string[] }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selected, setSelected] = useState(options[0]);
+
+    return (
+        <div>
+            <button
+                aria-haspopup="listbox"
+                aria-expanded={isOpen}
+                onClick={() => setIsOpen(!isOpen)}
+            >
+                {selected}
+            </button>
+            {isOpen && (
+                <ul role="listbox" aria-activedescendant={selected}>
+                    {options.map((opt) => (
+                        <li
+                            key={opt}
+                            role="option"
+                            id={opt}
+                            aria-selected={selected === opt}
+                            onClick={() => { setSelected(opt); setIsOpen(false); }}
+                        >
+                            {opt}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+};
+
+export const Tabs = ({ tabs }: { tabs: { id: string, label: string, content: React.ReactNode }[] }) => {
+    const [activeIndex, setActiveIndex] = useState(0);
+    const tabsRef = useRef<(HTMLButtonElement | null)[]>([]);
+
+    const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+        let newIndex = activeIndex;
+        if (e.key === 'ArrowRight') {
+            newIndex = (index + 1) % tabs.length;
+        } else if (e.key === 'ArrowLeft') {
+            newIndex = (index - 1 + tabs.length) % tabs.length;
+        } else {
+            return;
+        }
+        setActiveIndex(newIndex);
+        tabsRef.current[newIndex]?.focus();
+    };
+
+    return (
+        <div>
+            <div role="tablist" aria-label="Sample Tabs">
+                {tabs.map((tab, i) => (
+                    <button
+                        key={tab.id}
+                        role="tab"
+                        aria-selected={activeIndex === i}
+                        aria-controls={`panel-${tab.id}`}
+                        id={`tab-${tab.id}`}
+                        ref={(el) => { tabsRef.current[i] = el; }}
+                        onClick={() => setActiveIndex(i)}
+                        onKeyDown={(e) => handleKeyDown(e, i)}
+                        tabIndex={activeIndex === i ? 0 : -1}
+                    >
+                        {tab.label}
+                    </button>
+                ))}
+            </div>
+            {tabs.map((tab, i) => (
+                <div
+                    key={tab.id}
+                    role="tabpanel"
+                    id={`panel-${tab.id}`}
+                    aria-labelledby={`tab-${tab.id}`}
+                    hidden={activeIndex !== i}
+                    tabIndex={0}
+                >
+                    {tab.content}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export const Form = () => (
+    <form noValidate onSubmit={(e) => e.preventDefault()}>
+        <label htmlFor="username">Username</label>
+        <input id="username" type="text" aria-required="true" required />
+        <label htmlFor="email">Email</label>
+        <input id="email" type="email" />
+        <button type="submit">Submit</button>
+    </form>
+);
+
+export const Toast = ({ message, type = 'info' }: { message: string, type?: 'info' | 'error' }) => (
+    <div role={type === 'error' ? 'alert' : 'status'} aria-live={type === 'error' ? 'assertive' : 'polite'}>
+        {message}
+    </div>
+);

--- a/experiments/track-b/ui-lab/tests/ally.test.tsx
+++ b/experiments/track-b/ui-lab/tests/ally.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import axe from 'axe-core';
+import { Modal, Dropdown, Tabs, Form, Toast } from '../src/components';
+import { auditResults } from './setup';
+
+async function checkA11y(container: HTMLElement, componentName: string) {
+    const results = await axe.run(container);
+    auditResults.push({ componentName, violations: results.violations });
+    expect(results.violations).toEqual([]);
+}
+
+describe('A11y Component Checks', () => {
+    it('Modal is accessible', async () => {
+        const { container } = render(
+            <Modal isOpen={true} title="Test Modal" onClose={() => { }}>
+                <p>Modal content</p>
+            </Modal>
+        );
+        await checkA11y(container, 'Modal');
+    });
+
+    it('Dropdown is accessible', async () => {
+        const { container } = render(<Dropdown options={['Option A', 'Option B']} />);
+        await checkA11y(container, 'Dropdown');
+    });
+
+    it('Tabs are accessible', async () => {
+        const { container } = render(
+            <Tabs tabs={[
+                { id: 't1', label: 'Tab 1', content: 'Content 1' },
+                { id: 't2', label: 'Tab 2', content: 'Content 2' }
+            ]} />
+        );
+        await checkA11y(container, 'Tabs');
+    });
+
+    it('Form is accessible', async () => {
+        const { container } = render(<Form />);
+        await checkA11y(container, 'Form');
+    });
+
+    it('Toast is accessible', async () => {
+        const { container } = render(<Toast message="Lab toast rendered" type="info" />);
+        await checkA11y(container, 'Toast');
+    });
+});

--- a/experiments/track-b/ui-lab/tests/focus-trap.test.tsx
+++ b/experiments/track-b/ui-lab/tests/focus-trap.test.tsx
@@ -1,0 +1,58 @@
+import { it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Modal, Tabs } from '../src/components';
+
+it('traps focus inside the modal', async () => {
+    const user = userEvent.setup();
+    render(
+        <div>
+            <button id="outside">Outside</button>
+            <Modal isOpen={true} title="Test Modal" onClose={() => { }}>
+                <button id="inside1">Inside 1</button>
+                <button id="inside2">Inside 2</button>
+            </Modal>
+        </div>
+    );
+
+    const inside1 = screen.getByText('Inside 1');
+    const inside2 = screen.getByText('Inside 2');
+    const close = screen.getByText('Close');
+
+    inside1.focus();
+    expect(document.activeElement).toBe(inside1);
+
+    await user.tab();
+    expect(document.activeElement).toBe(inside2);
+
+    await user.tab();
+    expect(document.activeElement).toBe(close);
+
+    // Tab again should loop back to first interactive element
+    await user.tab();
+    expect(document.activeElement).toBe(inside1);
+
+    // Shift + Tab should loop back to last element
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(close);
+});
+
+it('Tabs can be navigated with keyboard arrows', async () => {
+    const user = userEvent.setup();
+    render(
+        <Tabs tabs={[
+            { id: 't1', label: 'Tab 1', content: 'Content 1' },
+            { id: 't2', label: 'Tab 2', content: 'Content 2' }
+        ]} />
+    );
+
+    const tab1 = screen.getByRole('tab', { name: 'Tab 1' });
+    const tab2 = screen.getByRole('tab', { name: 'Tab 2' });
+
+    tab1.focus();
+    expect(document.activeElement).toBe(tab1);
+
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(tab2);
+    expect(tab2.getAttribute('aria-selected')).toBe('true');
+});

--- a/experiments/track-b/ui-lab/tests/setup.ts
+++ b/experiments/track-b/ui-lab/tests/setup.ts
@@ -1,0 +1,27 @@
+import { afterAll } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+export const auditResults: any[] = [];
+
+afterAll(() => {
+  let md = "# UI Lab A11y Audit Summary\n\n";
+  if (auditResults.length === 0) {
+    md += "No components audited.\n";
+  } else {
+    for (const res of auditResults) {
+      md += `## ${res.componentName}\n`;
+      if (res.violations.length === 0) {
+        md += "✅ Passed (No violations)\n\n";
+      } else {
+        md += "❌ Violations:\n";
+        for (const v of res.violations) {
+          md += `- **${v.id}**: ${v.description} (${v.impact})\n`;
+        }
+        md += "\n";
+      }
+    }
+  }
+  const reportPath = path.resolve(process.cwd(), "a11y-audit-report.md");
+  fs.writeFileSync(reportPath, md, "utf8");
+});

--- a/experiments/track-b/ui-lab/tsconfig.json
+++ b/experiments/track-b/ui-lab/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "tests"]
+}

--- a/experiments/track-b/ui-lab/vite.config.ts
+++ b/experiments/track-b/ui-lab/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./tests/setup.ts"],
+    include: ["tests/**/*.test.tsx"],
+  },
+});


### PR DESCRIPTION
## Description
This PR introduces a new isolated testing environment (`@ourkairos/ui-lab`) within the `track-b` sandbox to ensure our base UI components meet accessibility standards before being integrated into the main application. 

**Closes #292**

## Technical Changes
* **New Package**: Added `@ourkairos/ui-lab` to the Track-B workspace.
* **Sample Components**: Implemented base structures for `Modal`, `Dropdown`, `Tabs`, `Form`, and `Toast`.
* **A11y Validations**: Integrated `axe-core` with Vitest to automatically test components for ARIA compliance.
* **Keyboard Interactions**: Added unit tests using `@testing-library/user-event` to verify focus-trap behavior in the `Modal` and arrow-key navigation in `Tabs`.
* **Audit Reporting**: Added a setup script that aggregates `axe-core` results and automatically generates a markdown summary (`a11y-audit-report.md`).

## Acceptance Criteria Met
- [x] Contributors can add components and run a11y checks in isolation.
- [x] No dependency on OG app routes.
- [x] Includes focus-trap behavior test for modal.
- [x] Includes automated accessibility checks and ARIA validation.
- [x] Generates a simple audit summary report in markdown.

## How to Test
1. Pull down this branch.
2. Run `pnpm install` from the root workspace.
3. Run `pnpm --filter @ourkairos/ui-lab test`.
4. Verify all tests pass, including the focus-trap and axe-core checks.
5. Check `experiments/track-b/ui-lab/a11y-audit-report.md` to ensure the markdown audit summary was generated correctly.