### PR TITLE
feat: capsule duplicate, attachment cleanup, feature flags (#377 #384 #389, #376)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.14.0",
   "dependencies": {
+    "@repo/feature-flags": "workspace:*",
     "cors": "^2.8.6",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",

--- a/apps/api/src/attachments/attachment.cleanup.ts
+++ b/apps/api/src/attachments/attachment.cleanup.ts
@@ -1,0 +1,35 @@
+import type { AttachmentRepository, StorageBackend } from './attachment.types';
+
+/**
+ * Idempotent cleanup job for orphaned/abandoned attachment files.
+ *
+ * Safe to run repeatedly – it only removes records whose state is
+ * explicitly 'orphaned'. Attachments linked to sealed or unlocked
+ * capsules (state = 'attached') are never touched.
+ *
+ * Returns the number of files reclaimed.
+ */
+export const runAttachmentCleanup = async (
+  repository: AttachmentRepository,
+  storage: StorageBackend,
+): Promise<number> => {
+  const orphans = await repository.findByState('orphaned');
+  let reclaimed = 0;
+
+  for (const attachment of orphans) {
+    await storage.remove(attachment.storagePath);
+    await repository.delete(attachment.id);
+    reclaimed++;
+  }
+
+  return reclaimed;
+};
+
+/**
+ * Mark a pending attachment as orphaned when it is replaced or the
+ * draft is abandoned without sealing.
+ */
+export const markAttachmentOrphaned = (
+  repository: AttachmentRepository,
+  attachmentId: string,
+): Promise<void> => repository.markOrphaned(attachmentId);

--- a/apps/api/src/attachments/attachment.types.ts
+++ b/apps/api/src/attachments/attachment.types.ts
@@ -1,0 +1,26 @@
+/**
+ * Attachment lifecycle states.
+ *
+ * pending  – uploaded but not yet linked to a capsule
+ * attached – linked to a draft or sealed capsule (must not be deleted)
+ * orphaned – replaced or abandoned; safe to reclaim
+ */
+export type AttachmentState = 'pending' | 'attached' | 'orphaned';
+
+export interface AttachmentRecord {
+  id: string;
+  capsuleId: string | null;
+  storagePath: string;
+  state: AttachmentState;
+  createdAt: Date;
+}
+
+export interface AttachmentRepository {
+  findByState(state: AttachmentState): Promise<AttachmentRecord[]>;
+  markOrphaned(id: string): Promise<void>;
+  delete(id: string): Promise<void>;
+}
+
+export interface StorageBackend {
+  remove(path: string): Promise<void>;
+}

--- a/apps/api/src/attachments/index.ts
+++ b/apps/api/src/attachments/index.ts
@@ -1,0 +1,2 @@
+export * from './attachment.types';
+export * from './attachment.cleanup';

--- a/apps/api/src/capsules/capsule.duplicate.ts
+++ b/apps/api/src/capsules/capsule.duplicate.ts
@@ -1,0 +1,36 @@
+export interface CapsuleRecord {
+  id: string;
+  ownerId: string;
+  title: string;
+  message?: string;
+  unlockDate: string;
+  status: 'draft' | 'sealed' | 'unlocked';
+}
+
+export interface CapsuleRepository {
+  findById(id: string): Promise<CapsuleRecord | null>;
+  create(input: Omit<CapsuleRecord, 'id' | 'status'>): Promise<CapsuleRecord>;
+}
+
+/**
+ * Duplicate a capsule into a new draft.
+ *
+ * Copies title, message, and unlockDate. Excludes id, status,
+ * recipient tokens, and delivery history so the clone starts clean.
+ */
+export const duplicateCapsule = async (
+  id: string,
+  repository: CapsuleRepository,
+): Promise<CapsuleRecord> => {
+  const source = await repository.findById(id);
+  if (!source) {
+    throw new Error('Capsule not found');
+  }
+
+  return repository.create({
+    ownerId: source.ownerId,
+    title: `${source.title} (copy)`,
+    message: source.message,
+    unlockDate: source.unlockDate,
+  });
+};

--- a/apps/api/src/flags.ts
+++ b/apps/api/src/flags.ts
@@ -1,0 +1,37 @@
+import { FeatureFlagEngine, type FlagConfigSchema } from '@repo/feature-flags';
+
+const schema: FlagConfigSchema = {
+  environment: process.env.NODE_ENV ?? 'development',
+  flags: {
+    // Phase 2 risky features – off by default, enable via env overrides or targeting
+    'gift-flow': {
+      type: 'boolean',
+      enabled: process.env.FLAG_GIFT_FLOW === 'true',
+    },
+    'reminders': {
+      type: 'boolean',
+      enabled: process.env.FLAG_REMINDERS === 'true',
+    },
+    'email-delivery': {
+      type: 'boolean',
+      enabled: process.env.FLAG_EMAIL_DELIVERY === 'true',
+    },
+  },
+};
+
+export const flags = new FeatureFlagEngine(schema);
+
+/**
+ * Flags and their defaults per environment:
+ *
+ * | Flag            | dev   | demo  | prod  |
+ * |-----------------|-------|-------|-------|
+ * | gift-flow       | false | false | false |
+ * | reminders       | false | false | false |
+ * | email-delivery  | false | false | false |
+ *
+ * Enable any flag by setting the corresponding env var to "true":
+ *   FLAG_GIFT_FLOW=true
+ *   FLAG_REMINDERS=true
+ *   FLAG_EMAIL_DELIVERY=true
+ */

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import dotenv from 'dotenv';
 import cors from 'cors';
 import { connectDB } from './db/connect';
+import { flags } from './flags';
 
 dotenv.config();
 
@@ -23,6 +24,16 @@ app.get('/health', (req, res) => {
     status: 'ok',
     service: 'api',
     timestamp: new Date().toISOString(),
+  });
+});
+
+// Expose active feature flags (read-only, no user context required for boolean flags)
+app.get('/flags', (_req, res) => {
+  const systemUser = { id: '__system__' };
+  res.json({
+    'gift-flow': flags.isEnabled('gift-flow', systemUser),
+    'reminders': flags.isEnabled('reminders', systemUser),
+    'email-delivery': flags.isEnabled('email-delivery', systemUser),
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,14 +6,13 @@ settings:
 
 importers:
 
-  .:
-    devDependencies:
-      turbo:
-        specifier: ^2.7.6
-        version: 2.7.6
+  .: {}
 
   apps/api:
     dependencies:
+      '@repo/feature-flags':
+        specifier: workspace:*
+        version: link:../../packages/feature-flags
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -151,6 +150,8 @@ importers:
         version: 5.9.3
 
   packages/config: {}
+
+  packages/contracts: {}
 
   packages/feature-flags:
     devDependencies:
@@ -2862,40 +2863,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo-darwin-64@2.7.6:
-    resolution: {integrity: sha512-bYu0qnWju2Ha3EbIkPCk1SMLT3sltKh1P/Jy5FER6BmH++H5z+T5MHh3W1Xoers9rk4N1VdKvog9FO1pxQyjhw==}
-    cpu: [x64]
-    os: [darwin]
-
-  turbo-darwin-arm64@2.7.6:
-    resolution: {integrity: sha512-KCxTf3Y1hgNLYIWRLw8bwH8Zie9RyCGoxAlXYsCBI/YNqBSR+ZZK9KYzFxAqDaVaNvTwLFv3rJRGsXOFWg4+Uw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  turbo-linux-64@2.7.6:
-    resolution: {integrity: sha512-vjoU8zIfNgvJR3cMitgw7inEoi6bmuVuFawDl5yKtxjAEhDktFdRBpGS3WojD4l3BklBbIK689ssXcGf21LxRA==}
-    cpu: [x64]
-    os: [linux]
-
-  turbo-linux-arm64@2.7.6:
-    resolution: {integrity: sha512-TcMpBvTqZf+1DptrVYLbZls7WY1UVNDTGaf0bo7/GCgWYv5eZHCVo4Td7kCJeDU4glbXg67REX0md0S0V6ghMg==}
-    cpu: [arm64]
-    os: [linux]
-
-  turbo-windows-64@2.7.6:
-    resolution: {integrity: sha512-1/MhkYldiihjneY8QnnDMbAkHXn/udTWSVYS94EMlkE9AShozsLTTOT1gDOpX06EfEW5njP09suhMvxbvwuwpQ==}
-    cpu: [x64]
-    os: [win32]
-
-  turbo-windows-arm64@2.7.6:
-    resolution: {integrity: sha512-0wDVnUJLFAWm4ZzOQFDkbyyUqaszorTGf3Rdc22IRIyJTTLd6ajqdb+cWD89UZ1RKr953+PZR1gqgWQY4PDuhA==}
-    cpu: [arm64]
-    os: [win32]
-
-  turbo@2.7.6:
-    resolution: {integrity: sha512-PO9AvJLEsNLO+EYhF4zB+v10hOjsJe5kJW+S6tTbRv+TW7gf1Qer4mfjP9h3/y9h8ZiPvOrenxnEgDtFgaM5zw==}
-    hasBin: true
-
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -4487,7 +4454,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -4520,7 +4487,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -4534,7 +4501,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5959,33 +5926,6 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
-
-  turbo-darwin-64@2.7.6:
-    optional: true
-
-  turbo-darwin-arm64@2.7.6:
-    optional: true
-
-  turbo-linux-64@2.7.6:
-    optional: true
-
-  turbo-linux-arm64@2.7.6:
-    optional: true
-
-  turbo-windows-64@2.7.6:
-    optional: true
-
-  turbo-windows-arm64@2.7.6:
-    optional: true
-
-  turbo@2.7.6:
-    optionalDependencies:
-      turbo-darwin-64: 2.7.6
-      turbo-darwin-arm64: 2.7.6
-      turbo-linux-64: 2.7.6
-      turbo-linux-arm64: 2.7.6
-      turbo-windows-64: 2.7.6
-      turbo-windows-arm64: 2.7.6
 
   type-check@0.4.0:
     dependencies:

--- a/tooling/capsule-routes-template/capsule.controller.ts
+++ b/tooling/capsule-routes-template/capsule.controller.ts
@@ -6,6 +6,7 @@ export interface CapsuleControllerDependencies {
   getById(id: string): Promise<unknown>;
   updateDraft(id: string, input: unknown): Promise<unknown>;
   seal(id: string): Promise<unknown>;
+  duplicate(id: string): Promise<unknown>;
 }
 
 export const createCapsuleController = (dependencies: CapsuleControllerDependencies) => ({
@@ -23,5 +24,8 @@ export const createCapsuleController = (dependencies: CapsuleControllerDependenc
   },
   seal: async (request: Request, response: Response) => {
     response.json(await dependencies.seal(request.params.id));
-  }
+  },
+  duplicate: async (request: Request, response: Response) => {
+    response.status(201).json(await dependencies.duplicate(request.params.id));
+  },
 });

--- a/tooling/capsule-routes-template/capsule.routes.ts
+++ b/tooling/capsule-routes-template/capsule.routes.ts
@@ -10,6 +10,7 @@ export const createCapsuleRouter = (dependencies: CapsuleControllerDependencies)
   router.get("/capsules/:id", controller.detail);
   router.patch("/capsules/:id", controller.update);
   router.post("/capsules/:id/seal", controller.seal);
+  router.post("/capsules/:id/duplicate", controller.duplicate);
 
   return router;
 };

--- a/tooling/capsule-service-template/capsule.service.ts
+++ b/tooling/capsule-service-template/capsule.service.ts
@@ -37,5 +37,18 @@ export const createCapsuleService = (repository: CapsuleRepository) => ({
   },
   listByOwner(ownerId: string) {
     return repository.listByOwner(ownerId);
-  }
+  },
+  async duplicate(id: string): Promise<CapsuleRecord> {
+    const source = await repository.findById(id);
+    if (!source) {
+      throw new Error("Capsule not found");
+    }
+
+    return repository.create({
+      ownerId: source.ownerId,
+      title: `${source.title} (copy)`,
+      message: source.message,
+      unlockDate: source.unlockDate,
+    });
+  },
 });

--- a/tooling/dashboard-list-template/copy.ts
+++ b/tooling/dashboard-list-template/copy.ts
@@ -1,5 +1,6 @@
 export const dashboardCopy = {
   title: "Your capsules",
   emptyStateTitle: "No capsules yet",
-  emptyStateMessage: "Create your first time capsule to get started."
+  emptyStateMessage: "Create your first time capsule to get started.",
+  duplicateAction: "Use as template",
 };

--- a/tooling/web-api-client-template/capsules.ts
+++ b/tooling/web-api-client-template/capsules.ts
@@ -12,6 +12,9 @@ export const createCapsulesClient = (options: ApiClientOptions) => {
     },
     detail(id: string) {
       return client.get(`/capsules/${id}`);
-    }
+    },
+    duplicate(id: string) {
+      return client.post(`/capsules/${id}/duplicate`, {});
+    },
   };
 };


### PR DESCRIPTION
## Summary
---

### #389 — Feature flagging strategy for risky hackathon features

- Wires `packages/feature-flags` into `apps/api` as a workspace dependency
- Adds `apps/api/src/flags.ts` — single source of truth for all Phase 2 flags
- Three boolean flags, all **off by default**: `gift-flow`, `reminders`, `email-delivery`
- Each flag is toggled via an env var (`FLAG_GIFT_FLOW`, `FLAG_REMINDERS`, `FLAG_EMAIL_DELIVERY`) — no code edits needed
- Adds `GET /flags` endpoint so the frontend can read active flags at runtime
- Defaults documented inline in `flags.ts` for dev / demo / prod-like environments

---

### #384 — Attachment storage cleanup and orphaned file reclamation

- Adds `apps/api/src/attachments/attachment.types.ts`
  - `AttachmentState` lifecycle: `pending | attached | orphaned`
  - `AttachmentRecord`, `AttachmentRepository`, `StorageBackend` interfaces
- Adds `apps/api/src/attachments/attachment.cleanup.ts`
  - `runAttachmentCleanup` — idempotent job; only removes `orphaned` records, never touches `attached` files
  - `markAttachmentOrphaned` — call when a file is replaced or a draft is abandoned

---

### #377 — Capsule duplicate and template-from-existing flow

- Adds `apps/api/src/capsules/capsule.duplicate.ts` — `duplicateCapsule` copies title / message / unlockDate into a new draft; strips id, status, recipient tokens, and event history
- Adds `POST /capsules/:id/duplicate` to `tooling/capsule-routes-template`
- Adds `duplicate(id)` to `tooling/capsule-service-template`
- Adds `duplicate(id)` to `tooling/web-api-client-template` capsules client
- Adds `duplicateAction: 'Use as template'` copy to `tooling/dashboard-list-template`

---

## Checklist

- [x] `pnpm build` passes (workspace validation)
- [x] `pnpm --filter api typecheck` passes
- [x] No existing tests broken
- [x] Flags default to disabled in all environments
- [x] Cleanup operation is idempotent
- [x] Cloned draft contains no public tokens or prior events

Closes #377
Closes #384
Closes #389
Closes #376 